### PR TITLE
Implement SqueezeTGZ tool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module squeezetgz
+
+go 1.24
+
+require github.com/klauspost/compress v1.17.9
+

--- a/main.go
+++ b/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	windowMode := flag.Bool("window", true, "use compression window optimizing mode")
+	bruteMode := flag.Bool("brute", false, "use brute force mode")
+	flag.Parse()
+
+	if flag.NArg() != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s [--window|--brute] <input.tar.gz> <output.tar.gz>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	if *bruteMode {
+		*windowMode = false
+	}
+
+	inPath := flag.Arg(0)
+	outPath := flag.Arg(1)
+
+	files, err := readTarGZ(inPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to read input: %v\n", err)
+		os.Exit(1)
+	}
+
+	var ordered []TarFile
+	if *windowMode {
+		ordered = reorderWindow(files)
+	} else {
+		ordered = reorderBrute(files)
+	}
+
+	err = writeTarGZ(outPath, ordered)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write output: %v\n", err)
+		os.Exit(1)
+	}
+
+	beforeInfo, err := os.Stat(inPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stat input: %v\n", err)
+		os.Exit(1)
+	}
+	afterInfo, err := os.Stat(outPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to stat output: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Before: %d KB\n", beforeInfo.Size()/1024)
+	fmt.Printf("After: %d KB\n", afterInfo.Size()/1024)
+}

--- a/squeeze.go
+++ b/squeeze.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	kgzip "github.com/klauspost/compress/gzip"
+)
+
+type TarFile struct {
+	Header *tar.Header
+	Data   []byte
+}
+
+type checksum struct {
+	hdr  [32]byte
+	data [32]byte
+}
+
+func readTarGZ(path string) ([]TarFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	gz, err := kgzip.NewReader(f)
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var files []TarFile
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		data := make([]byte, hdr.Size)
+		if _, err := io.ReadFull(tr, data); err != nil {
+			return nil, err
+		}
+		hcopy := *hdr
+		files = append(files, TarFile{Header: &hcopy, Data: data})
+	}
+	return files, nil
+}
+
+func writeTarGZ(path string, files []TarFile) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gz, err := kgzip.NewWriterLevel(f, kgzip.BestCompression)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tw := tar.NewWriter(gz)
+	for _, tf := range files {
+		if err := tw.WriteHeader(tf.Header); err != nil {
+			return err
+		}
+		if _, err := tw.Write(tf.Data); err != nil {
+			return err
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return err
+	}
+	return gz.Close()
+}
+
+const windowSize = 32 * 1024
+
+func compressRatio(b []byte) float64 {
+	var buf bytes.Buffer
+	w, _ := kgzip.NewWriterLevel(&buf, kgzip.BestCompression)
+	w.Write(b)
+	w.Close()
+	if len(b) == 0 {
+		return 0
+	}
+	return float64(buf.Len()) / float64(len(b))
+}
+
+func checksumFiles(files []TarFile) []checksum {
+	sums := make([]checksum, len(files))
+	for i, f := range files {
+		hdrBytes := []byte(fmt.Sprintf("%v", f.Header))
+		sums[i].hdr = sha256.Sum256(hdrBytes)
+		sums[i].data = sha256.Sum256(f.Data)
+	}
+	return sums
+}
+
+func validateChecksums(files []TarFile, sums []checksum) bool {
+	if len(files) != len(sums) {
+		return false
+	}
+	for i, f := range files {
+		hdrBytes := []byte(fmt.Sprintf("%v", f.Header))
+		if sha := sha256.Sum256(hdrBytes); sha != sums[i].hdr {
+			return false
+		}
+		if sha := sha256.Sum256(f.Data); sha != sums[i].data {
+			return false
+		}
+	}
+	return true
+}
+
+func reorderWindow(files []TarFile) []TarFile {
+	if len(files) == 0 {
+		return nil
+	}
+	remaining := make([]TarFile, len(files))
+	copy(remaining, files)
+	// start with file with best compression on last half
+	sort.Slice(remaining, func(i, j int) bool {
+		a := compressRatio(lastHalf(remaining[i].Data))
+		b := compressRatio(lastHalf(remaining[j].Data))
+		return a < b
+	})
+	ordered := []TarFile{remaining[0]}
+	remaining = remaining[1:]
+
+	for len(remaining) > 0 {
+		prev := ordered[len(ordered)-1]
+		sort.Slice(remaining, func(i, j int) bool {
+			a := overlapScore(prev.Data, remaining[i].Data)
+			b := overlapScore(prev.Data, remaining[j].Data)
+			return a > b
+		})
+		ordered = append(ordered, remaining[0])
+		remaining = remaining[1:]
+	}
+	return ordered
+}
+
+func reorderBrute(files []TarFile) []TarFile {
+	best := make([]TarFile, len(files))
+	var bestSize int64 = -1
+	permute(files, func(p []TarFile) {
+		size := estimateSize(p)
+		if bestSize == -1 || size < bestSize {
+			bestSize = size
+			copy(best, p)
+		}
+	})
+	return best
+}
+
+func estimateSize(files []TarFile) int64 {
+	// compress concatenated data
+	pr, pw := io.Pipe()
+	gz, _ := kgzip.NewWriterLevel(pw, kgzip.BestCompression)
+	go func() {
+		tw := tar.NewWriter(gz)
+		for _, f := range files {
+			tw.WriteHeader(f.Header)
+			tw.Write(f.Data)
+		}
+		tw.Close()
+		gz.Close()
+		pw.Close()
+	}()
+	n, _ := io.Copy(io.Discard, pr)
+	pr.Close()
+	return n
+}
+
+func permute(files []TarFile, fn func([]TarFile)) {
+	var helper func(int)
+	helper = func(i int) {
+		if i == len(files) {
+			tmp := make([]TarFile, len(files))
+			copy(tmp, files)
+			fn(tmp)
+			return
+		}
+		for j := i; j < len(files); j++ {
+			files[i], files[j] = files[j], files[i]
+			helper(i + 1)
+			files[i], files[j] = files[j], files[i]
+		}
+	}
+	helper(0)
+}
+
+func lastHalf(b []byte) []byte {
+	if len(b) <= windowSize/2 {
+		return b
+	}
+	return b[len(b)-windowSize/2:]
+}
+
+func firstHalf(b []byte) []byte {
+	if len(b) <= windowSize/2 {
+		return b
+	}
+	return b[:windowSize/2]
+}
+
+func overlapScore(a, b []byte) int {
+	ah := lastHalf(a)
+	bh := firstHalf(b)
+	max := len(ah)
+	if len(bh) < max {
+		max = len(bh)
+	}
+	score := 0
+	for i := 0; i < max; i++ {
+		if ah[len(ah)-1-i] == bh[len(bh)-1-i] {
+			score++
+		} else {
+			break
+		}
+	}
+	return score
+}

--- a/squeeze_test.go
+++ b/squeeze_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/rand"
+	"os"
+	"testing"
+)
+
+func genTestFiles() []TarFile {
+	half := windowSize / 2
+	makeSeq := func(b byte) []byte { return bytes.Repeat([]byte{b}, half) }
+
+	seqA1 := makeSeq('A')
+	seqA2 := makeSeq('B')
+	seqB1 := makeSeq('C')
+	seqC2 := makeSeq('D')
+
+	files := []TarFile{
+		{Header: &tar.Header{Name: "file1", Mode: 0644, Size: int64(len(seqA1) + len(seqA2))}, Data: append(append([]byte{}, seqA1...), seqA2...)},
+		{Header: &tar.Header{Name: "file2", Mode: 0644, Size: int64(len(seqB1) + len(seqA1))}, Data: append(append([]byte{}, seqB1...), seqA1...)},
+		{Header: &tar.Header{Name: "file3", Mode: 0644, Size: int64(len(seqA2) + len(seqC2))}, Data: append(append([]byte{}, seqA2...), seqC2...)},
+		{Header: &tar.Header{Name: "file4", Mode: 0644, Size: int64(len(seqC2) + len(seqB1))}, Data: append(append([]byte{}, seqC2...), seqB1...)},
+	}
+
+	noise1 := make([]byte, windowSize)
+	rand.Read(noise1)
+	noise2 := make([]byte, windowSize)
+	rand.Read(noise2)
+	files = append(files, TarFile{Header: &tar.Header{Name: "noise1", Mode: 0644, Size: int64(len(noise1))}, Data: noise1})
+	files = append(files, TarFile{Header: &tar.Header{Name: "noise2", Mode: 0644, Size: int64(len(noise2))}, Data: noise2})
+
+	return files
+}
+
+func fileNames(fs []TarFile) []string {
+	names := make([]string, len(fs))
+	for i, f := range fs {
+		names[i] = f.Header.Name
+	}
+	return names
+}
+
+func TestReorderAlgorithmsAgree(t *testing.T) {
+	files := genTestFiles()
+	win := reorderWindow(files)
+	brute := reorderBrute(files)
+
+	wn := fileNames(win)
+	bn := fileNames(brute)
+	if len(wn) != len(bn) {
+		t.Fatalf("length mismatch")
+	}
+	for i := range wn {
+		if wn[i] != bn[i] {
+			t.Fatalf("order mismatch at %d: %s vs %s", i, wn[i], bn[i])
+		}
+	}
+}
+
+func TestWriteRead(t *testing.T) {
+	files := genTestFiles()
+	sums := checksumFiles(files)
+	tmp, err := os.CreateTemp(t.TempDir(), "out*.tar.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTarGZ(tmp.Name(), files); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+	out, err := readTarGZ(tmp.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validateChecksums(out, sums) {
+		t.Fatalf("checksums mismatch")
+	}
+}


### PR DESCRIPTION
## Summary
- create Go module and implement SqueezeTGZ main program
- support compression-window and brute force reordering algorithms
- use `klauspost/compress` for gzip operations
- add tests that generate synthetic tar files and verify both algorithms agree
- fix compression ratio calculation

## Testing
- `go test ./...` *(fails: no route to host)*